### PR TITLE
C++ MFC 파일 좌표 읽어 컨트롤 위치 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,64 @@
-# MFC 텍스트 컨트롤 위치 변경 예제
+# MFC TextControl 좌표 변경 예제
 
-이 프로젝트는 C언어 파일 입출력을 사용하여 좌표 파일에서 좌표를 읽어와서 MFC 다이얼로그의 텍스트 컨트롤 위치를 동적으로 변경하는 예제입니다.
+이 프로젝트는 C언어와 MFC를 사용하여 파일에서 좌표를 읽어와서 텍스트 컨트롤의 위치를 동적으로 변경하는 방법을 보여주는 예제입니다.
 
 ## 파일 구성
 
-1. **coordinates.txt** - 텍스트 컨트롤의 좌표 데이터 파일
-2. **TextControlDlg.h** - MFC 다이얼로그 헤더 파일
-3. **TextControlDlg.cpp** - MFC 다이얼로그 구현 파일
-4. **resource.h** - 리소스 ID 정의
-5. **TextControlDlg.rc** - 리소스 스크립트 파일
+- `coordinates.txt`: 좌표 데이터가 저장된 텍스트 파일
+- `TextControlDlg.h`: MFC 다이얼로그 헤더 파일
+- `TextControlDlg.cpp`: 메인 구현 파일 (파일 읽기 및 컨트롤 위치 변경 로직)
+- `resource.h`: 리소스 ID 정의
+- `TextControlApp.rc`: MFC 리소스 파일
 
 ## 주요 기능
 
-### 1. 좌표 파일 형식
+1. **파일에서 좌표 읽기**: `coordinates.txt` 파일에서 x, y, width, height 값을 읽어옵니다.
+2. **동적 위치 변경**: 읽어온 좌표를 사용하여 TextControl의 위치와 크기를 실시간으로 변경합니다.
+3. **사용자 인터페이스**: 파일 선택 다이얼로그를 통해 좌표 파일을 선택할 수 있습니다.
+
+## 좌표 파일 형식
+
 ```
-# 텍스트 컨트롤의 좌표 (x, y, width, height)
-# TextControl1
+# 좌표 파일 형식: x y width height
+# TextControl의 위치와 크기 정보
 100 50 200 25
-# TextControl2  
-150 100 250 30
-# TextControl3
-200 150 180 25
+150 100 180 30
+200 150 160 20
 ```
 
-### 2. 핵심 함수들
+- 각 줄은 하나의 TextControl에 대한 좌표를 나타냅니다.
+- 순서대로 x좌표, y좌표, 너비, 높이를 의미합니다.
+- `#`으로 시작하는 줄은 주석으로 처리됩니다.
 
-- **LoadCoordinatesFromFile()**: C언어 스타일 파일 읽기 함수
-- **MoveTextControl()**: 텍스트 컨트롤 위치 변경 함수
-- **OnBnClickedLoadCoordinates()**: 좌표 파일 로드 버튼 이벤트 핸들러
-- **OnBnClickedResetPositions()**: 위치 리셋 버튼 이벤트 핸들러
+## 핵심 함수
 
-### 3. C언어 파일 입출력 특징
-
+### `LoadCoordinatesFromFile()`
 ```cpp
-// 순수 C 스타일 파일 읽기
-FILE* file = nullptr;
-errno_t err = _tfopen_s(&file, filePath, _T("r"));
-
-char line[256];
-while (fgets(line, sizeof(line), file) && coordIndex < 3)
-{
-    // 좌표 파싱
-    int x, y, width, height;
-    if (sscanf_s(line, "%d %d %d %d", &x, &y, &width, &height) == 4)
-    {
-        // 좌표 저장
-    }
-}
+BOOL LoadCoordinatesFromFile(const CString& filename)
 ```
+- 파일에서 좌표 데이터를 읽어오는 함수
+- std::ifstream을 사용한 C++ 스타일 파일 읽기
+- 주석 라인과 빈 라인을 자동으로 건너뛰기
 
-## 사용 방법
+### `UpdateTextControlPosition()`
+```cpp
+void UpdateTextControlPosition(int controlID, const TextControlCoords& coords)
+```
+- 특정 컨트롤의 위치와 크기를 업데이트하는 함수
+- SetWindowPos()를 사용하여 컨트롤 위치 변경
+- 변경 후 화면 갱신
 
-1. MFC 프로젝트에 파일들을 추가
-2. 리소스 파일에서 다이얼로그와 컨트롤 ID 설정
-3. coordinates.txt 파일에 원하는 좌표 입력
-4. "좌표 파일 로드" 버튼으로 좌표 적용
-5. "위치 리셋" 버튼으로 원래 위치 복원
+## 컴파일 및 실행
 
-## 컴파일 요구사항
+1. Visual Studio에서 MFC 프로젝트를 생성합니다.
+2. 제공된 파일들을 프로젝트에 추가합니다.
+3. 프로젝트를 빌드하고 실행합니다.
+4. "좌표 파일 로드" 버튼을 클릭하여 coordinates.txt 파일을 선택합니다.
+5. 텍스트 컨트롤들의 위치가 파일에 정의된 좌표로 변경되는 것을 확인합니다.
 
-- Visual Studio with MFC
-- Windows SDK
-- C++/CLI 또는 C++ 표준 라이브러리
+## 기술적 특징
 
-## 특징
-
-- **순수 C 스타일 파일 입출력** 사용
-- **동적 컨트롤 위치 변경** 지원
-- **오류 처리** 및 **사용자 피드백** 제공
-- **원본 위치 복원** 기능
-- **주석이 있는 좌표 파일** 지원
+- **MFC 다이얼로그 기반**: Windows MFC 프레임워크 사용
+- **파일 I/O**: C++ 표준 라이브러리의 ifstream 사용
+- **동적 UI 변경**: 런타임에 컨트롤 위치 변경
+- **에러 처리**: 파일 읽기 실패 시 사용자에게 알림

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
-# MFC TextControl 좌표 변경 예제
+# MFC TextControl 좌표 변경 예제 (순수 C언어)
 
-이 프로젝트는 C언어와 MFC를 사용하여 파일에서 좌표를 읽어와서 텍스트 컨트롤의 위치를 동적으로 변경하는 방법을 보여주는 예제입니다.
+이 프로젝트는 **순수 C언어**와 MFC를 사용하여 파일에서 좌표를 읽어와서 텍스트 컨트롤의 위치를 동적으로 변경하는 방법을 보여주는 예제입니다.
 
 ## 파일 구성
 
+### MFC 통합 버전
 - `coordinates.txt`: 좌표 데이터가 저장된 텍스트 파일
-- `TextControlDlg.h`: MFC 다이얼로그 헤더 파일
-- `TextControlDlg.cpp`: 메인 구현 파일 (파일 읽기 및 컨트롤 위치 변경 로직)
+- `TextControlDlg.h`: MFC 다이얼로그 헤더 파일 (C언어 스타일로 수정됨)
+- `TextControlDlg.cpp`: C++ 스타일의 원본 구현 파일
+- `TextControlDlg_C_Style.cpp`: **순수 C언어 스타일**로 작성된 MFC 구현 파일
 - `resource.h`: 리소스 ID 정의
 - `TextControlApp.rc`: MFC 리소스 파일
+
+### 순수 C언어 독립 버전
+- `pure_c_example.c`: MFC 없이 **순수 C언어만**으로 작성된 파일 읽기 예제
 
 ## 주요 기능
 
@@ -32,21 +37,41 @@
 
 ## 핵심 함수
 
-### `LoadCoordinatesFromFile()`
-```cpp
-BOOL LoadCoordinatesFromFile(const CString& filename)
-```
-- 파일에서 좌표 데이터를 읽어오는 함수
-- std::ifstream을 사용한 C++ 스타일 파일 읽기
-- 주석 라인과 빈 라인을 자동으로 건너뛰기
+### C언어 스타일 MFC 버전
 
-### `UpdateTextControlPosition()`
-```cpp
-void UpdateTextControlPosition(int controlID, const TextControlCoords& coords)
+#### `LoadCoordinatesFromFile_CStyle()`
+```c
+BOOL LoadCoordinatesFromFile_CStyle(const CString& filename)
 ```
-- 특정 컨트롤의 위치와 크기를 업데이트하는 함수
+- **순수 C언어 스타일**로 작성된 파일 읽기 함수
+- `fopen_s()`, `fgets()`, `sscanf_s()` 사용
+- `strtok_s()`를 이용한 대안적 파싱 방법 제공
+
+#### `UpdateTextControlPosition_CStyle()`
+```c
+void UpdateTextControlPosition_CStyle(int controlIndex, const TextControlCoords* coords)
+```
+- C언어 스타일 포인터 사용
+- 구조체 포인터를 통한 데이터 접근
 - SetWindowPos()를 사용하여 컨트롤 위치 변경
-- 변경 후 화면 갱신
+
+### 순수 C언어 독립 버전
+
+#### `load_coordinates_from_file()`
+```c
+int load_coordinates_from_file(const char* filename, Coordinates coords[], int max_count)
+```
+- MFC 없이 순수 C언어로만 작성
+- `fopen()`, `fgets()`, `sscanf()` 사용
+- 파싱 실패 시 `strtok_r()` 대안 제공
+
+#### `parse_coordinate_line_manual()`
+```c
+int parse_coordinate_line_manual(const char* line, Coordinates* coord)
+```
+- 라이브러리 함수 없이 수동 파싱
+- 문자열 포인터 직접 조작
+- 완전히 독립적인 C언어 구현
 
 ## 컴파일 및 실행
 
@@ -58,7 +83,32 @@ void UpdateTextControlPosition(int controlID, const TextControlCoords& coords)
 
 ## 기술적 특징
 
+### MFC 버전
 - **MFC 다이얼로그 기반**: Windows MFC 프레임워크 사용
-- **파일 I/O**: C++ 표준 라이브러리의 ifstream 사용
+- **순수 C언어 파일 I/O**: `fopen_s()`, `fgets()`, `sscanf_s()` 사용
+- **C언어 스타일 문자열 처리**: `strtok_s()`, 포인터 직접 조작
 - **동적 UI 변경**: 런타임에 컨트롤 위치 변경
-- **에러 처리**: 파일 읽기 실패 시 사용자에게 알림
+- **구조체 포인터**: C언어 스타일 데이터 구조 사용
+
+### 순수 C언어 버전
+- **완전한 C언어**: MFC나 C++ 기능 없이 순수 C언어만 사용
+- **표준 C 라이브러리**: `stdio.h`, `stdlib.h`, `string.h`만 사용
+- **수동 메모리 관리**: `malloc()`, `free()` 사용
+- **다양한 파싱 방법**: `sscanf()`, `strtok_r()`, 수동 파싱 제공
+- **크로스 플랫폼**: Unix/Linux에서도 컴파일 가능
+
+## C언어 파일 I/O 특징
+
+### 사용된 C언어 함수들
+```c
+FILE* fopen_s(&file, filename, "r");  // 안전한 파일 열기
+fgets(line, sizeof(line), file);      // 한 줄씩 읽기
+sscanf_s(line, "%d %d %d %d", ...);   // 안전한 문자열 파싱
+strtok_s(line, " \t", &context);      // 안전한 토큰 분리
+fclose(file);                         // 파일 닫기
+```
+
+### 메모리 안전성
+- **버퍼 오버플로우 방지**: `fgets()`, `sscanf_s()` 사용
+- **안전한 문자열 함수**: `strtok_s()` 사용
+- **NULL 포인터 검사**: 모든 포인터 사용 전 검증

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# MFC 텍스트 컨트롤 위치 변경 예제
+
+이 프로젝트는 C언어 파일 입출력을 사용하여 좌표 파일에서 좌표를 읽어와서 MFC 다이얼로그의 텍스트 컨트롤 위치를 동적으로 변경하는 예제입니다.
+
+## 파일 구성
+
+1. **coordinates.txt** - 텍스트 컨트롤의 좌표 데이터 파일
+2. **TextControlDlg.h** - MFC 다이얼로그 헤더 파일
+3. **TextControlDlg.cpp** - MFC 다이얼로그 구현 파일
+4. **resource.h** - 리소스 ID 정의
+5. **TextControlDlg.rc** - 리소스 스크립트 파일
+
+## 주요 기능
+
+### 1. 좌표 파일 형식
+```
+# 텍스트 컨트롤의 좌표 (x, y, width, height)
+# TextControl1
+100 50 200 25
+# TextControl2  
+150 100 250 30
+# TextControl3
+200 150 180 25
+```
+
+### 2. 핵심 함수들
+
+- **LoadCoordinatesFromFile()**: C언어 스타일 파일 읽기 함수
+- **MoveTextControl()**: 텍스트 컨트롤 위치 변경 함수
+- **OnBnClickedLoadCoordinates()**: 좌표 파일 로드 버튼 이벤트 핸들러
+- **OnBnClickedResetPositions()**: 위치 리셋 버튼 이벤트 핸들러
+
+### 3. C언어 파일 입출력 특징
+
+```cpp
+// 순수 C 스타일 파일 읽기
+FILE* file = nullptr;
+errno_t err = _tfopen_s(&file, filePath, _T("r"));
+
+char line[256];
+while (fgets(line, sizeof(line), file) && coordIndex < 3)
+{
+    // 좌표 파싱
+    int x, y, width, height;
+    if (sscanf_s(line, "%d %d %d %d", &x, &y, &width, &height) == 4)
+    {
+        // 좌표 저장
+    }
+}
+```
+
+## 사용 방법
+
+1. MFC 프로젝트에 파일들을 추가
+2. 리소스 파일에서 다이얼로그와 컨트롤 ID 설정
+3. coordinates.txt 파일에 원하는 좌표 입력
+4. "좌표 파일 로드" 버튼으로 좌표 적용
+5. "위치 리셋" 버튼으로 원래 위치 복원
+
+## 컴파일 요구사항
+
+- Visual Studio with MFC
+- Windows SDK
+- C++/CLI 또는 C++ 표준 라이브러리
+
+## 특징
+
+- **순수 C 스타일 파일 입출력** 사용
+- **동적 컨트롤 위치 변경** 지원
+- **오류 처리** 및 **사용자 피드백** 제공
+- **원본 위치 복원** 기능
+- **주석이 있는 좌표 파일** 지원

--- a/TextControlApp.rc
+++ b/TextControlApp.rc
@@ -1,0 +1,182 @@
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE 2에서 생성되었습니다.
+//
+#ifndef APSTUDIO_INVOKED
+#include "targetver.h"
+#endif
+#include "afxres.h"
+#include "verrsrc.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// 한국어(대한민국) 리소스
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_KOR)
+LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#ifndef APSTUDIO_INVOKED\r\n"
+    "#include ""targetver.h""\r\n"
+    "#endif\r\n"
+    "#include ""afxres.h""\r\n"
+    "#include ""verrsrc.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#define _AFX_NO_SPLITTER_RESOURCES\r\n"
+    "#define _AFX_NO_OLE_RESOURCES\r\n"
+    "#define _AFX_NO_TRACKER_RESOURCES\r\n"
+    "#define _AFX_NO_PROPERTY_RESOURCES\r\n"
+    "\r\n"
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_KOR)\r\n"
+    "LANGUAGE 18, 1\r\n"
+    "#include ""res\\TextControlApp.rc2""  // Microsoft Visual C++에서 편집하지 않은 리소스입니다.\r\n"
+    "#include ""l.KOR\\afxres.rc""      // 표준 구성 요소\r\n"
+    "#if !defined(_AFXDLL)\r\n"
+    "#include ""l.KOR\\afxribbon.rc""   // MFC 리본 및 컨트롤 막대 리소스\r\n"
+    "#endif\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Icon
+//
+
+// Icon with lowest ID value placed first to ensure application icon
+// remains consistent on all systems.
+IDR_MAINFRAME           ICON                    "res\\TextControlApp.ico"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_ABOUTBOX DIALOGEX 0, 0, 170, 62
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "TextControlApp 정보"
+FONT 9, "MS Shell Dlg", 0, 0, 0x1
+BEGIN
+    ICON            IDR_MAINFRAME,IDC_STATIC,14,14,21,20
+    LTEXT           "TextControlApp, 버전 1.0",IDC_STATIC,42,14,114,8,SS_NOPREFIX
+    LTEXT           "Copyright (C) 2024",IDC_STATIC,42,26,114,8
+    DEFPUSHBUTTON   "확인",IDOK,113,41,50,14,WS_GROUP
+END
+
+IDD_TEXTCONTROL_DIALOG DIALOGEX 0, 0, 400, 300
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+EXSTYLE WS_EX_APPWINDOW
+CAPTION "TextControl 위치 변경 예제"
+FONT 9, "MS Shell Dlg", 0, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "확인",IDOK,290,260,50,14
+    PUSHBUTTON      "취소",IDCANCEL,343,260,50,14
+    LTEXT           "텍스트 컨트롤 1",IDC_TEXT_CONTROL1,20,30,100,20,SS_SUNKEN
+    LTEXT           "텍스트 컨트롤 2",IDC_TEXT_CONTROL2,20,70,100,20,SS_SUNKEN
+    LTEXT           "텍스트 컨트롤 3",IDC_TEXT_CONTROL3,20,110,100,20,SS_SUNKEN
+    PUSHBUTTON      "좌표 파일 로드",IDC_BTN_LOAD_COORDS,20,200,80,25
+    GROUPBOX        "설명",IDC_STATIC,200,30,180,120
+    LTEXT           "이 예제는 파일에서 좌표를 읽어와서\r\nTextControl의 위치를 동적으로 변경하는\r\n방법을 보여줍니다.\r\n\r\n좌표 파일 형식:\r\nx y width height\r\n\r\n예시:\r\n100 50 200 25\r\n150 100 180 30\r\n200 150 160 20",IDC_STATIC,210,45,160,95
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    IDD_ABOUTBOX, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 163
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 55
+    END
+
+    IDD_TEXTCONTROL_DIALOG, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 393
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 293
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_TEXTCONTROL_DIALOG AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_ABOUTBOX            "TextControlApp 정보(&A)..."
+END
+
+#endif    // 한국어(대한민국) 리소스
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE 3에서 생성되었습니다.
+//
+
+#define _AFX_NO_SPLITTER_RESOURCES
+#define _AFX_NO_OLE_RESOURCES
+#define _AFX_NO_TRACKER_RESOURCES
+#define _AFX_NO_PROPERTY_RESOURCES
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_KOR)
+LANGUAGE 18, 1
+#include "res\TextControlApp.rc2"  // Microsoft Visual C++에서 편집하지 않은 리소스입니다.
+#include "l.KOR\afxres.rc"      // 표준 구성 요소
+#if !defined(_AFXDLL)
+#include "l.KOR\afxribbon.rc"   // MFC 리본 및 컨트롤 막대 리소스
+#endif
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // APSTUDIO_INVOKED 아님

--- a/TextControlDlg.cpp
+++ b/TextControlDlg.cpp
@@ -1,0 +1,214 @@
+#include "pch.h"
+#include "TextControlDlg.h"
+#include "afxdialogex.h"
+#include <fstream>
+#include <sstream>
+
+// CTextControlDlg 대화 상자
+
+IMPLEMENT_DYNAMIC(CTextControlDlg, CDialogEx)
+
+CTextControlDlg::CTextControlDlg(CWnd* pParent /*=nullptr*/)
+    : CDialogEx(IDD_TEXTCONTROL_DIALOG, pParent)
+{
+    // 좌표 초기화
+    memset(m_coordinates, 0, sizeof(m_coordinates));
+    memset(m_originalCoords, 0, sizeof(m_originalCoords));
+}
+
+CTextControlDlg::~CTextControlDlg()
+{
+}
+
+void CTextControlDlg::DoDataExchange(CDataExchange* pDX)
+{
+    CDialogEx::DoDataExchange(pDX);
+    DDX_Control(pDX, IDC_TEXT_CONTROL1, m_textControl1);
+    DDX_Control(pDX, IDC_TEXT_CONTROL2, m_textControl2);
+    DDX_Control(pDX, IDC_TEXT_CONTROL3, m_textControl3);
+}
+
+BEGIN_MESSAGE_MAP(CTextControlDlg, CDialogEx)
+    ON_BN_CLICKED(IDC_LOAD_COORDINATES, &CTextControlDlg::OnBnClickedLoadCoordinates)
+    ON_BN_CLICKED(IDC_RESET_POSITIONS, &CTextControlDlg::OnBnClickedResetPositions)
+END_MESSAGE_MAP()
+
+// CTextControlDlg 메시지 처리기
+
+BOOL CTextControlDlg::OnInitDialog()
+{
+    CDialogEx::OnInitDialog();
+
+    // 원본 좌표 저장
+    CRect rect;
+    
+    if (m_textControl1.GetSafeHwnd())
+    {
+        m_textControl1.GetWindowRect(&rect);
+        ScreenToClient(&rect);
+        m_originalCoords[0] = {rect.left, rect.top, rect.Width(), rect.Height()};
+    }
+    
+    if (m_textControl2.GetSafeHwnd())
+    {
+        m_textControl2.GetWindowRect(&rect);
+        ScreenToClient(&rect);
+        m_originalCoords[1] = {rect.left, rect.top, rect.Width(), rect.Height()};
+    }
+    
+    if (m_textControl3.GetSafeHwnd())
+    {
+        m_textControl3.GetWindowRect(&rect);
+        ScreenToClient(&rect);
+        m_originalCoords[2] = {rect.left, rect.top, rect.Width(), rect.Height()};
+    }
+
+    // 텍스트 컨트롤에 초기 텍스트 설정
+    m_textControl1.SetWindowText(_T("텍스트 컨트롤 1"));
+    m_textControl2.SetWindowText(_T("텍스트 컨트롤 2"));
+    m_textControl3.SetWindowText(_T("텍스트 컨트롤 3"));
+
+    return TRUE;
+}
+
+void CTextControlDlg::OnBnClickedLoadCoordinates()
+{
+    // 파일 선택 대화상자
+    CFileDialog dlg(TRUE, _T("txt"), _T("coordinates.txt"),
+        OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT,
+        _T("Text Files (*.txt)|*.txt|All Files (*.*)|*.*||"));
+
+    if (dlg.DoModal() == IDOK)
+    {
+        CString filePath = dlg.GetPathName();
+        
+        if (LoadCoordinatesFromFile(filePath))
+        {
+            // 텍스트 컨트롤들의 위치 변경
+            MoveTextControl(&m_textControl1, m_coordinates[0]);
+            MoveTextControl(&m_textControl2, m_coordinates[1]);
+            MoveTextControl(&m_textControl3, m_coordinates[2]);
+            
+            // 화면 갱신
+            Invalidate();
+            
+            MessageBox(_T("좌표를 성공적으로 로드하여 적용했습니다."), _T("성공"), MB_OK | MB_ICONINFORMATION);
+        }
+        else
+        {
+            MessageBox(_T("좌표 파일을 읽는데 실패했습니다."), _T("오류"), MB_OK | MB_ICONERROR);
+        }
+    }
+}
+
+void CTextControlDlg::OnBnClickedResetPositions()
+{
+    // 원본 위치로 복원
+    MoveTextControl(&m_textControl1, m_originalCoords[0]);
+    MoveTextControl(&m_textControl2, m_originalCoords[1]);
+    MoveTextControl(&m_textControl3, m_originalCoords[2]);
+    
+    // 화면 갱신
+    Invalidate();
+    
+    MessageBox(_T("텍스트 컨트롤들을 원래 위치로 복원했습니다."), _T("복원 완료"), MB_OK | MB_ICONINFORMATION);
+}
+
+BOOL CTextControlDlg::LoadCoordinatesFromFile(const CString& filePath)
+{
+    // C 스타일 파일 읽기 (C언어 스타일)
+    FILE* file = nullptr;
+    errno_t err = _tfopen_s(&file, filePath, _T("r"));
+    
+    if (err != 0 || file == nullptr)
+    {
+        return FALSE;
+    }
+
+    char line[256];
+    int coordIndex = 0;
+    
+    while (fgets(line, sizeof(line), file) && coordIndex < 3)
+    {
+        // 주석 라인이나 빈 라인 건너뛰기
+        if (line[0] == '#' || line[0] == '\n' || line[0] == '\r')
+            continue;
+            
+        // 좌표 파싱 (x, y, width, height)
+        int x, y, width, height;
+        if (sscanf_s(line, "%d %d %d %d", &x, &y, &width, &height) == 4)
+        {
+            m_coordinates[coordIndex].x = x;
+            m_coordinates[coordIndex].y = y;
+            m_coordinates[coordIndex].width = width;
+            m_coordinates[coordIndex].height = height;
+            coordIndex++;
+        }
+    }
+    
+    fclose(file);
+    
+    // 3개의 좌표를 모두 읽었는지 확인
+    return (coordIndex == 3);
+}
+
+void CTextControlDlg::MoveTextControl(CWnd* pControl, const Coordinates& coords)
+{
+    if (pControl && pControl->GetSafeHwnd())
+    {
+        // 컨트롤의 위치와 크기 변경
+        pControl->MoveWindow(coords.x, coords.y, coords.width, coords.height, TRUE);
+    }
+}
+
+// 대안적인 파일 읽기 방법 (더 순수한 C 스타일)
+/*
+BOOL CTextControlDlg::LoadCoordinatesFromFile_CStyle(const CString& filePath)
+{
+    // CString을 char*로 변환
+    CT2A converter(filePath);
+    char* fileName = converter;
+    
+    FILE* file = fopen(fileName, "r");
+    if (file == NULL)
+    {
+        return FALSE;
+    }
+
+    int coordIndex = 0;
+    char buffer[256];
+    
+    while (fgets(buffer, sizeof(buffer), file) != NULL && coordIndex < 3)
+    {
+        // 주석이나 빈 줄 건너뛰기
+        if (buffer[0] == '#' || buffer[0] == '\n')
+            continue;
+            
+        // strtok을 사용한 파싱
+        char* token = strtok(buffer, " \t\n");
+        if (token == NULL) continue;
+        
+        int values[4];
+        int valueIndex = 0;
+        
+        while (token != NULL && valueIndex < 4)
+        {
+            values[valueIndex] = atoi(token);
+            valueIndex++;
+            token = strtok(NULL, " \t\n");
+        }
+        
+        if (valueIndex == 4)
+        {
+            m_coordinates[coordIndex].x = values[0];
+            m_coordinates[coordIndex].y = values[1];
+            m_coordinates[coordIndex].width = values[2];
+            m_coordinates[coordIndex].height = values[3];
+            coordIndex++;
+        }
+    }
+    
+    fclose(file);
+    return (coordIndex == 3);
+}
+*/

--- a/TextControlDlg.cpp
+++ b/TextControlDlg.cpp
@@ -1,214 +1,248 @@
 #include "pch.h"
+#include "framework.h"
 #include "TextControlDlg.h"
 #include "afxdialogex.h"
 #include <fstream>
 #include <sstream>
 
-// CTextControlDlg 대화 상자
+#ifdef _DEBUG
+#define new DEBUG_NEW
+#endif
 
-IMPLEMENT_DYNAMIC(CTextControlDlg, CDialogEx)
+// 응용 프로그램 정보에 사용되는 CAboutDlg 대화 상자입니다.
 
-CTextControlDlg::CTextControlDlg(CWnd* pParent /*=nullptr*/)
-    : CDialogEx(IDD_TEXTCONTROL_DIALOG, pParent)
+class CAboutDlg : public CDialogEx
 {
-    // 좌표 초기화
-    memset(m_coordinates, 0, sizeof(m_coordinates));
-    memset(m_originalCoords, 0, sizeof(m_originalCoords));
+public:
+	CAboutDlg();
+
+// 대화 상자 데이터입니다.
+#ifdef AFX_DESIGN_TIME
+	enum { IDD = IDD_ABOUTBOX };
+#endif
+
+	protected:
+	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV 지원입니다.
+
+// 구현입니다.
+protected:
+	DECLARE_MESSAGE_MAP()
+};
+
+CAboutDlg::CAboutDlg() : CDialogEx(IDD_ABOUTBOX)
+{
 }
 
-CTextControlDlg::~CTextControlDlg()
+void CAboutDlg::DoDataExchange(CDataExchange* pDX)
 {
+	CDialogEx::DoDataExchange(pDX);
+}
+
+BEGIN_MESSAGE_MAP(CAboutDlg, CDialogEx)
+END_MESSAGE_MAP()
+
+
+// CTextControlDlg 대화 상자
+
+CTextControlDlg::CTextControlDlg(CWnd* pParent /*=nullptr*/)
+	: CDialogEx(IDD_TEXTCONTROL_DIALOG, pParent)
+{
+	m_hIcon = AfxGetApp()->LoadIcon(IDR_MAINFRAME);
 }
 
 void CTextControlDlg::DoDataExchange(CDataExchange* pDX)
 {
-    CDialogEx::DoDataExchange(pDX);
-    DDX_Control(pDX, IDC_TEXT_CONTROL1, m_textControl1);
-    DDX_Control(pDX, IDC_TEXT_CONTROL2, m_textControl2);
-    DDX_Control(pDX, IDC_TEXT_CONTROL3, m_textControl3);
+	CDialogEx::DoDataExchange(pDX);
+	DDX_Control(pDX, IDC_TEXT_CONTROL1, m_textControl1);
+	DDX_Control(pDX, IDC_TEXT_CONTROL2, m_textControl2);
+	DDX_Control(pDX, IDC_TEXT_CONTROL3, m_textControl3);
+	DDX_Control(pDX, IDC_BTN_LOAD_COORDS, m_btnLoadCoords);
 }
 
 BEGIN_MESSAGE_MAP(CTextControlDlg, CDialogEx)
-    ON_BN_CLICKED(IDC_LOAD_COORDINATES, &CTextControlDlg::OnBnClickedLoadCoordinates)
-    ON_BN_CLICKED(IDC_RESET_POSITIONS, &CTextControlDlg::OnBnClickedResetPositions)
+	ON_WM_SYSCOMMAND()
+	ON_WM_PAINT()
+	ON_WM_QUERYDRAGICON()
+	ON_BN_CLICKED(IDC_BTN_LOAD_COORDS, &CTextControlDlg::OnBnClickedLoadCoordinates)
 END_MESSAGE_MAP()
+
 
 // CTextControlDlg 메시지 처리기
 
 BOOL CTextControlDlg::OnInitDialog()
 {
-    CDialogEx::OnInitDialog();
+	CDialogEx::OnInitDialog();
 
-    // 원본 좌표 저장
-    CRect rect;
-    
-    if (m_textControl1.GetSafeHwnd())
-    {
-        m_textControl1.GetWindowRect(&rect);
-        ScreenToClient(&rect);
-        m_originalCoords[0] = {rect.left, rect.top, rect.Width(), rect.Height()};
-    }
-    
-    if (m_textControl2.GetSafeHwnd())
-    {
-        m_textControl2.GetWindowRect(&rect);
-        ScreenToClient(&rect);
-        m_originalCoords[1] = {rect.left, rect.top, rect.Width(), rect.Height()};
-    }
-    
-    if (m_textControl3.GetSafeHwnd())
-    {
-        m_textControl3.GetWindowRect(&rect);
-        ScreenToClient(&rect);
-        m_originalCoords[2] = {rect.left, rect.top, rect.Width(), rect.Height()};
-    }
+	// 시스템 메뉴에 "정보..." 메뉴 항목을 추가합니다.
 
-    // 텍스트 컨트롤에 초기 텍스트 설정
-    m_textControl1.SetWindowText(_T("텍스트 컨트롤 1"));
-    m_textControl2.SetWindowText(_T("텍스트 컨트롤 2"));
-    m_textControl3.SetWindowText(_T("텍스트 컨트롤 3"));
+	// IDM_ABOUTBOX는 시스템 명령 범위에 있어야 합니다.
+	ASSERT((IDM_ABOUTBOX & 0xFFF0) == IDM_ABOUTBOX);
+	ASSERT(IDM_ABOUTBOX < 0xF000);
 
-    return TRUE;
+	CMenu* pSysMenu = GetSystemMenu(FALSE);
+	if (pSysMenu != nullptr)
+	{
+		BOOL bNameValid;
+		CString strAboutMenu;
+		bNameValid = strAboutMenu.LoadString(IDS_ABOUTBOX);
+		ASSERT(bNameValid);
+		if (!strAboutMenu.IsEmpty())
+		{
+			pSysMenu->AppendMenu(MF_SEPARATOR);
+			pSysMenu->AppendMenu(MF_STRING, IDM_ABOUTBOX, strAboutMenu);
+		}
+	}
+
+	// 이 대화 상자의 아이콘을 설정합니다.  응용 프로그램의 주 창이 대화 상자가 아닐 경우에는
+	//  프레임워크가 이 작업을 자동으로 수행합니다.
+	SetIcon(m_hIcon, TRUE);			// 큰 아이콘을 설정합니다.
+	SetIcon(m_hIcon, FALSE);		// 작은 아이콘을 설정합니다.
+
+	// TODO: 여기에 추가 초기화 작업을 추가합니다.
+	
+	// 텍스트 컨트롤에 초기 텍스트 설정
+	m_textControl1.SetWindowText(_T("Text Control 1"));
+	m_textControl2.SetWindowText(_T("Text Control 2"));
+	m_textControl3.SetWindowText(_T("Text Control 3"));
+
+	return TRUE;  // 포커스를 컨트롤에 설정하지 않으면 TRUE를 반환합니다.
 }
 
+void CTextControlDlg::OnSysCommand(UINT nID, LPARAM lParam)
+{
+	if ((nID & 0xFFF0) == IDM_ABOUTBOX)
+	{
+		CAboutDlg dlgAbout;
+		dlgAbout.DoModal();
+	}
+	else
+	{
+		CDialogEx::OnSysCommand(nID, lParam);
+	}
+}
+
+// 대화 상자에 최소화 단추를 추가할 경우 아이콘을 그리려면
+//  아래 코드가 필요합니다.  문서/뷰 모델을 사용하는 MFC 응용 프로그램의 경우에는
+//  프레임워크에서 이 작업을 자동으로 수행합니다.
+
+void CTextControlDlg::OnPaint()
+{
+	if (IsIconic())
+	{
+		CPaintDC dc(this); // 그리기를 위한 디바이스 컨텍스트입니다.
+
+		SendMessage(WM_ICONERASEBKGND, reinterpret_cast<WPARAM>(dc.GetSafeHdc()), 0);
+
+		// 클라이언트 사각형에서 아이콘을 가운데에 맞춥니다.
+		int cxIcon = GetSystemMetrics(SM_CXICON);
+		int cyIcon = GetSystemMetrics(SM_CYICON);
+		CRect rect;
+		GetClientRect(&rect);
+		int x = (rect.Width() - cxIcon + 1) / 2;
+		int y = (rect.Height() - cyIcon + 1) / 2;
+
+		// 아이콘을 그립니다.
+		dc.DrawIcon(x, y, m_hIcon);
+	}
+	else
+	{
+		CDialogEx::OnPaint();
+	}
+}
+
+// 사용자가 최소화된 창을 끄는 동안에 커서가 표시되도록 시스템에서
+//  이 함수를 호출합니다.
+HCURSOR CTextControlDlg::OnQueryDragIcon()
+{
+	return static_cast<HCURSOR>(m_hIcon);
+}
+
+// 좌표 로드 버튼 클릭 이벤트 핸들러
 void CTextControlDlg::OnBnClickedLoadCoordinates()
 {
-    // 파일 선택 대화상자
-    CFileDialog dlg(TRUE, _T("txt"), _T("coordinates.txt"),
-        OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT,
-        _T("Text Files (*.txt)|*.txt|All Files (*.*)|*.*||"));
+	// 파일 선택 대화상자
+	CFileDialog fileDlg(TRUE, _T("txt"), NULL, 
+		OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT,
+		_T("텍스트 파일 (*.txt)|*.txt|모든 파일 (*.*)|*.*||"));
 
-    if (dlg.DoModal() == IDOK)
-    {
-        CString filePath = dlg.GetPathName();
-        
-        if (LoadCoordinatesFromFile(filePath))
-        {
-            // 텍스트 컨트롤들의 위치 변경
-            MoveTextControl(&m_textControl1, m_coordinates[0]);
-            MoveTextControl(&m_textControl2, m_coordinates[1]);
-            MoveTextControl(&m_textControl3, m_coordinates[2]);
-            
-            // 화면 갱신
-            Invalidate();
-            
-            MessageBox(_T("좌표를 성공적으로 로드하여 적용했습니다."), _T("성공"), MB_OK | MB_ICONINFORMATION);
-        }
-        else
-        {
-            MessageBox(_T("좌표 파일을 읽는데 실패했습니다."), _T("오류"), MB_OK | MB_ICONERROR);
-        }
-    }
+	if (fileDlg.DoModal() == IDOK)
+	{
+		CString filePath = fileDlg.GetPathName();
+		if (LoadCoordinatesFromFile(filePath))
+		{
+			MessageBox(_T("좌표가 성공적으로 로드되었습니다."), _T("성공"), MB_OK | MB_ICONINFORMATION);
+		}
+		else
+		{
+			MessageBox(_T("좌표 파일을 읽는데 실패했습니다."), _T("오류"), MB_OK | MB_ICONERROR);
+		}
+	}
 }
 
-void CTextControlDlg::OnBnClickedResetPositions()
+// 파일에서 좌표를 읽어오는 함수
+BOOL CTextControlDlg::LoadCoordinatesFromFile(const CString& filename)
 {
-    // 원본 위치로 복원
-    MoveTextControl(&m_textControl1, m_originalCoords[0]);
-    MoveTextControl(&m_textControl2, m_originalCoords[1]);
-    MoveTextControl(&m_textControl3, m_originalCoords[2]);
-    
-    // 화면 갱신
-    Invalidate();
-    
-    MessageBox(_T("텍스트 컨트롤들을 원래 위치로 복원했습니다."), _T("복원 완료"), MB_OK | MB_ICONINFORMATION);
+	std::ifstream file;
+	file.open(CStringA(filename));
+
+	if (!file.is_open())
+	{
+		return FALSE;
+	}
+
+	std::string line;
+	int controlIndex = 0;
+	
+	// 파일에서 한 줄씩 읽기
+	while (std::getline(file, line) && controlIndex < 3)
+	{
+		// 주석 라인이나 빈 라인 건너뛰기
+		if (line.empty() || line[0] == '#')
+		{
+			continue;
+		}
+
+		// 좌표 파싱
+		std::istringstream iss(line);
+		TextControlCoords coords;
+		
+		if (iss >> coords.x >> coords.y >> coords.width >> coords.height)
+		{
+			// 각 텍스트 컨트롤의 위치 업데이트
+			switch (controlIndex)
+			{
+			case 0:
+				UpdateTextControlPosition(IDC_TEXT_CONTROL1, coords);
+				break;
+			case 1:
+				UpdateTextControlPosition(IDC_TEXT_CONTROL2, coords);
+				break;
+			case 2:
+				UpdateTextControlPosition(IDC_TEXT_CONTROL3, coords);
+				break;
+			}
+			controlIndex++;
+		}
+	}
+
+	file.close();
+	return (controlIndex > 0); // 최소 하나의 좌표는 로드되어야 함
 }
 
-BOOL CTextControlDlg::LoadCoordinatesFromFile(const CString& filePath)
+// 텍스트 컨트롤의 위치를 업데이트하는 함수
+void CTextControlDlg::UpdateTextControlPosition(int controlID, const TextControlCoords& coords)
 {
-    // C 스타일 파일 읽기 (C언어 스타일)
-    FILE* file = nullptr;
-    errno_t err = _tfopen_s(&file, filePath, _T("r"));
-    
-    if (err != 0 || file == nullptr)
-    {
-        return FALSE;
-    }
+	CWnd* pControl = GetDlgItem(controlID);
+	if (pControl != nullptr)
+	{
+		// 컨트롤의 위치와 크기 변경
+		pControl->SetWindowPos(nullptr, 
+			coords.x, coords.y, 
+			coords.width, coords.height,
+			SWP_NOZORDER | SWP_SHOWWINDOW);
 
-    char line[256];
-    int coordIndex = 0;
-    
-    while (fgets(line, sizeof(line), file) && coordIndex < 3)
-    {
-        // 주석 라인이나 빈 라인 건너뛰기
-        if (line[0] == '#' || line[0] == '\n' || line[0] == '\r')
-            continue;
-            
-        // 좌표 파싱 (x, y, width, height)
-        int x, y, width, height;
-        if (sscanf_s(line, "%d %d %d %d", &x, &y, &width, &height) == 4)
-        {
-            m_coordinates[coordIndex].x = x;
-            m_coordinates[coordIndex].y = y;
-            m_coordinates[coordIndex].width = width;
-            m_coordinates[coordIndex].height = height;
-            coordIndex++;
-        }
-    }
-    
-    fclose(file);
-    
-    // 3개의 좌표를 모두 읽었는지 확인
-    return (coordIndex == 3);
+		// 다이얼로그 새로 그리기
+		Invalidate();
+		UpdateWindow();
+	}
 }
-
-void CTextControlDlg::MoveTextControl(CWnd* pControl, const Coordinates& coords)
-{
-    if (pControl && pControl->GetSafeHwnd())
-    {
-        // 컨트롤의 위치와 크기 변경
-        pControl->MoveWindow(coords.x, coords.y, coords.width, coords.height, TRUE);
-    }
-}
-
-// 대안적인 파일 읽기 방법 (더 순수한 C 스타일)
-/*
-BOOL CTextControlDlg::LoadCoordinatesFromFile_CStyle(const CString& filePath)
-{
-    // CString을 char*로 변환
-    CT2A converter(filePath);
-    char* fileName = converter;
-    
-    FILE* file = fopen(fileName, "r");
-    if (file == NULL)
-    {
-        return FALSE;
-    }
-
-    int coordIndex = 0;
-    char buffer[256];
-    
-    while (fgets(buffer, sizeof(buffer), file) != NULL && coordIndex < 3)
-    {
-        // 주석이나 빈 줄 건너뛰기
-        if (buffer[0] == '#' || buffer[0] == '\n')
-            continue;
-            
-        // strtok을 사용한 파싱
-        char* token = strtok(buffer, " \t\n");
-        if (token == NULL) continue;
-        
-        int values[4];
-        int valueIndex = 0;
-        
-        while (token != NULL && valueIndex < 4)
-        {
-            values[valueIndex] = atoi(token);
-            valueIndex++;
-            token = strtok(NULL, " \t\n");
-        }
-        
-        if (valueIndex == 4)
-        {
-            m_coordinates[coordIndex].x = values[0];
-            m_coordinates[coordIndex].y = values[1];
-            m_coordinates[coordIndex].width = values[2];
-            m_coordinates[coordIndex].height = values[3];
-            coordIndex++;
-        }
-    }
-    
-    fclose(file);
-    return (coordIndex == 3);
-}
-*/

--- a/TextControlDlg.h
+++ b/TextControlDlg.h
@@ -1,52 +1,47 @@
 #pragma once
-#include "afxdialogex.h"
 
 // CTextControlDlg 대화 상자
 
 class CTextControlDlg : public CDialogEx
 {
-    DECLARE_DYNAMIC(CTextControlDlg)
-
+// 생성입니다.
 public:
-    CTextControlDlg(CWnd* pParent = nullptr);   // 표준 생성자입니다.
-    virtual ~CTextControlDlg();
+	CTextControlDlg(CWnd* pParent = nullptr);	// 표준 생성자입니다.
 
 // 대화 상자 데이터입니다.
 #ifdef AFX_DESIGN_TIME
-    enum { IDD = IDD_TEXTCONTROL_DIALOG };
+	enum { IDD = IDD_TEXTCONTROL_DIALOG };
 #endif
 
 protected:
-    virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV 지원입니다.
+	virtual void DoDataExchange(CDataExchange* pDX);	// DDX/DDV 지원입니다.
 
-    DECLARE_MESSAGE_MAP()
+// 구현입니다.
+protected:
+	HICON m_hIcon;
 
-public:
-    // 텍스트 컨트롤 변수들
-    CStatic m_textControl1;
-    CStatic m_textControl2;
-    CStatic m_textControl3;
-
-    // 함수들
-    virtual BOOL OnInitDialog();
-    afx_msg void OnBnClickedLoadCoordinates();
-    afx_msg void OnBnClickedResetPositions();
+	// 생성된 메시지 맵 함수
+	virtual BOOL OnInitDialog();
+	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
+	afx_msg void OnPaint();
+	afx_msg HCURSOR OnQueryDragIcon();
+	afx_msg void OnBnClickedLoadCoordinates();
+	DECLARE_MESSAGE_MAP()
 
 private:
-    // 좌표 구조체
-    struct Coordinates {
-        int x, y, width, height;
-    };
+	// 좌표 구조체
+	struct TextControlCoords {
+		int x, y, width, height;
+	};
 
-    // 파일에서 좌표를 읽는 함수
-    BOOL LoadCoordinatesFromFile(const CString& filePath);
-    
-    // 텍스트 컨트롤의 위치를 변경하는 함수
-    void MoveTextControl(CWnd* pControl, const Coordinates& coords);
-    
-    // 좌표 배열
-    Coordinates m_coordinates[3];
-    
-    // 원본 좌표 저장 (리셋용)
-    Coordinates m_originalCoords[3];
+	// 멤버 함수
+	BOOL LoadCoordinatesFromFile(const CString& filename);
+	void UpdateTextControlPosition(int controlID, const TextControlCoords& coords);
+
+public:
+	// 컨트롤 변수
+	CStatic m_textControl1;
+	CStatic m_textControl2;
+	CStatic m_textControl3;
+	CButton m_btnLoadCoords;
 };

--- a/TextControlDlg.h
+++ b/TextControlDlg.h
@@ -1,0 +1,52 @@
+#pragma once
+#include "afxdialogex.h"
+
+// CTextControlDlg 대화 상자
+
+class CTextControlDlg : public CDialogEx
+{
+    DECLARE_DYNAMIC(CTextControlDlg)
+
+public:
+    CTextControlDlg(CWnd* pParent = nullptr);   // 표준 생성자입니다.
+    virtual ~CTextControlDlg();
+
+// 대화 상자 데이터입니다.
+#ifdef AFX_DESIGN_TIME
+    enum { IDD = IDD_TEXTCONTROL_DIALOG };
+#endif
+
+protected:
+    virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV 지원입니다.
+
+    DECLARE_MESSAGE_MAP()
+
+public:
+    // 텍스트 컨트롤 변수들
+    CStatic m_textControl1;
+    CStatic m_textControl2;
+    CStatic m_textControl3;
+
+    // 함수들
+    virtual BOOL OnInitDialog();
+    afx_msg void OnBnClickedLoadCoordinates();
+    afx_msg void OnBnClickedResetPositions();
+
+private:
+    // 좌표 구조체
+    struct Coordinates {
+        int x, y, width, height;
+    };
+
+    // 파일에서 좌표를 읽는 함수
+    BOOL LoadCoordinatesFromFile(const CString& filePath);
+    
+    // 텍스트 컨트롤의 위치를 변경하는 함수
+    void MoveTextControl(CWnd* pControl, const Coordinates& coords);
+    
+    // 좌표 배열
+    Coordinates m_coordinates[3];
+    
+    // 원본 좌표 저장 (리셋용)
+    Coordinates m_originalCoords[3];
+};

--- a/TextControlDlg.h
+++ b/TextControlDlg.h
@@ -29,14 +29,17 @@ protected:
 	DECLARE_MESSAGE_MAP()
 
 private:
-	// 좌표 구조체
-	struct TextControlCoords {
+	// C 언어 스타일 좌표 구조체
+	typedef struct {
 		int x, y, width, height;
-	};
+	} TextControlCoords;
 
-	// 멤버 함수
+	// C 언어 스타일 멤버 함수들
 	BOOL LoadCoordinatesFromFile(const CString& filename);
+	BOOL LoadCoordinatesFromFile_CStyle(const CString& filename);
+	BOOL LoadCoordinatesFromFile_BasicC(const CString& filename);
 	void UpdateTextControlPosition(int controlID, const TextControlCoords& coords);
+	void UpdateTextControlPosition_CStyle(int controlIndex, const TextControlCoords* coords);
 
 public:
 	// 컨트롤 변수

--- a/TextControlDlg.rc
+++ b/TextControlDlg.rc
@@ -1,0 +1,98 @@
+// Microsoft Visual C++에서 생성한 리소스 스크립트입니다.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE 2에서 생성되었습니다.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// 한국어(대한민국) 리소스
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_KOR)
+LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_TEXTCONTROL_DIALOG DIALOGEX 0, 0, 400, 300
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "텍스트 컨트롤 위치 변경 예제"
+FONT 9, "MS Shell Dlg", 0, 0, 0x1
+BEGIN
+    LTEXT           "텍스트 컨트롤 1",IDC_TEXT_CONTROL1,20,20,100,20,SS_CENTERIMAGE
+    LTEXT           "텍스트 컨트롤 2",IDC_TEXT_CONTROL2,20,50,100,20,SS_CENTERIMAGE
+    LTEXT           "텍스트 컨트롤 3",IDC_TEXT_CONTROL3,20,80,100,20,SS_CENTERIMAGE
+    PUSHBUTTON      "좌표 파일 로드",IDC_LOAD_COORDINATES,20,250,80,23
+    PUSHBUTTON      "위치 리셋",IDC_RESET_POSITIONS,110,250,80,23
+    DEFPUSHBUTTON   "확인",IDOK,200,250,50,23
+    PUSHBUTTON      "취소",IDCANCEL,260,250,50,23
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    IDD_TEXTCONTROL_DIALOG, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 393
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 293
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+#endif    // 한국어(대한민국) 리소스
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE 3에서 생성되었습니다.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // APSTUDIO_INVOKED 아님

--- a/TextControlDlg_C_Style.cpp
+++ b/TextControlDlg_C_Style.cpp
@@ -2,6 +2,8 @@
 #include "framework.h"
 #include "TextControlDlg.h"
 #include "afxdialogex.h"
+
+// C 언어 표준 라이브러리 포함
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,8 +12,15 @@
 #define new DEBUG_NEW
 #endif
 
-// 응용 프로그램 정보에 사용되는 CAboutDlg 대화 상자입니다.
+// 좌표 구조체 정의 (C 언어 스타일)
+typedef struct {
+    int x;
+    int y;
+    int width;
+    int height;
+} TextControlCoords;
 
+// 응용 프로그램 정보에 사용되는 CAboutDlg 대화 상자입니다.
 class CAboutDlg : public CDialogEx
 {
 public:
@@ -42,7 +51,6 @@ void CAboutDlg::DoDataExchange(CDataExchange* pDX)
 BEGIN_MESSAGE_MAP(CAboutDlg, CDialogEx)
 END_MESSAGE_MAP()
 
-
 // CTextControlDlg 대화 상자
 
 CTextControlDlg::CTextControlDlg(CWnd* pParent /*=nullptr*/)
@@ -67,7 +75,6 @@ BEGIN_MESSAGE_MAP(CTextControlDlg, CDialogEx)
 	ON_BN_CLICKED(IDC_BTN_LOAD_COORDS, &CTextControlDlg::OnBnClickedLoadCoordinates)
 END_MESSAGE_MAP()
 
-
 // CTextControlDlg 메시지 처리기
 
 BOOL CTextControlDlg::OnInitDialog()
@@ -75,8 +82,6 @@ BOOL CTextControlDlg::OnInitDialog()
 	CDialogEx::OnInitDialog();
 
 	// 시스템 메뉴에 "정보..." 메뉴 항목을 추가합니다.
-
-	// IDM_ABOUTBOX는 시스템 명령 범위에 있어야 합니다.
 	ASSERT((IDM_ABOUTBOX & 0xFFF0) == IDM_ABOUTBOX);
 	ASSERT(IDM_ABOUTBOX < 0xF000);
 
@@ -94,19 +99,15 @@ BOOL CTextControlDlg::OnInitDialog()
 		}
 	}
 
-	// 이 대화 상자의 아이콘을 설정합니다.  응용 프로그램의 주 창이 대화 상자가 아닐 경우에는
-	//  프레임워크가 이 작업을 자동으로 수행합니다.
 	SetIcon(m_hIcon, TRUE);			// 큰 아이콘을 설정합니다.
 	SetIcon(m_hIcon, FALSE);		// 작은 아이콘을 설정합니다.
 
-	// TODO: 여기에 추가 초기화 작업을 추가합니다.
-	
 	// 텍스트 컨트롤에 초기 텍스트 설정
 	m_textControl1.SetWindowText(_T("Text Control 1"));
 	m_textControl2.SetWindowText(_T("Text Control 2"));
 	m_textControl3.SetWindowText(_T("Text Control 3"));
 
-	return TRUE;  // 포커스를 컨트롤에 설정하지 않으면 TRUE를 반환합니다.
+	return TRUE;
 }
 
 void CTextControlDlg::OnSysCommand(UINT nID, LPARAM lParam)
@@ -122,19 +123,13 @@ void CTextControlDlg::OnSysCommand(UINT nID, LPARAM lParam)
 	}
 }
 
-// 대화 상자에 최소화 단추를 추가할 경우 아이콘을 그리려면
-//  아래 코드가 필요합니다.  문서/뷰 모델을 사용하는 MFC 응용 프로그램의 경우에는
-//  프레임워크에서 이 작업을 자동으로 수행합니다.
-
 void CTextControlDlg::OnPaint()
 {
 	if (IsIconic())
 	{
-		CPaintDC dc(this); // 그리기를 위한 디바이스 컨텍스트입니다.
-
+		CPaintDC dc(this);
 		SendMessage(WM_ICONERASEBKGND, reinterpret_cast<WPARAM>(dc.GetSafeHdc()), 0);
 
-		// 클라이언트 사각형에서 아이콘을 가운데에 맞춥니다.
 		int cxIcon = GetSystemMetrics(SM_CXICON);
 		int cyIcon = GetSystemMetrics(SM_CYICON);
 		CRect rect;
@@ -142,7 +137,6 @@ void CTextControlDlg::OnPaint()
 		int x = (rect.Width() - cxIcon + 1) / 2;
 		int y = (rect.Height() - cyIcon + 1) / 2;
 
-		// 아이콘을 그립니다.
 		dc.DrawIcon(x, y, m_hIcon);
 	}
 	else
@@ -151,8 +145,6 @@ void CTextControlDlg::OnPaint()
 	}
 }
 
-// 사용자가 최소화된 창을 끄는 동안에 커서가 표시되도록 시스템에서
-//  이 함수를 호출합니다.
 HCURSOR CTextControlDlg::OnQueryDragIcon()
 {
 	return static_cast<HCURSOR>(m_hIcon);
@@ -169,7 +161,7 @@ void CTextControlDlg::OnBnClickedLoadCoordinates()
 	if (fileDlg.DoModal() == IDOK)
 	{
 		CString filePath = fileDlg.GetPathName();
-		if (LoadCoordinatesFromFile(filePath))
+		if (LoadCoordinatesFromFile_CStyle(filePath))
 		{
 			MessageBox(_T("좌표가 성공적으로 로드되었습니다."), _T("성공"), MB_OK | MB_ICONINFORMATION);
 		}
@@ -180,14 +172,14 @@ void CTextControlDlg::OnBnClickedLoadCoordinates()
 	}
 }
 
-// 파일에서 좌표를 읽어오는 함수 (순수 C언어 스타일)
-BOOL CTextControlDlg::LoadCoordinatesFromFile(const CString& filename)
+// 순수 C 언어 스타일 파일 읽기 함수
+BOOL CTextControlDlg::LoadCoordinatesFromFile_CStyle(const CString& filename)
 {
 	// CString을 ANSI 문자열로 변환
 	CT2A converter(filename);
 	char* filePath = converter;
 	
-	// C언어 스타일 파일 열기
+	// C 언어 스타일 파일 열기
 	FILE* file = NULL;
 	errno_t err = fopen_s(&file, filePath, "r");
 	
@@ -196,20 +188,31 @@ BOOL CTextControlDlg::LoadCoordinatesFromFile(const CString& filename)
 		return FALSE;
 	}
 
-	char line[256];
+	char line[512];        // 라인 버퍼
+	char* token;           // 토큰 포인터
+	char* context = NULL;  // strtok_s 컨텍스트
 	int controlIndex = 0;
 	TextControlCoords coords;
 	
-	// 파일에서 한 줄씩 읽기
+	// 파일에서 한 줄씩 읽기 (C 언어 방식)
 	while (fgets(line, sizeof(line), file) != NULL && controlIndex < 3)
 	{
+		// 줄 끝의 개행 문자 제거
+		size_t len = strlen(line);
+		if (len > 0 && (line[len-1] == '\n' || line[len-1] == '\r'))
+		{
+			line[len-1] = '\0';
+			if (len > 1 && line[len-2] == '\r')
+				line[len-2] = '\0';
+		}
+		
 		// 주석 라인이나 빈 라인 건너뛰기
-		if (line[0] == '#' || line[0] == '\n' || line[0] == '\r' || line[0] == '\0')
+		if (line[0] == '#' || line[0] == '\0' || strlen(line) == 0)
 		{
 			continue;
 		}
 
-		// C언어 sscanf를 사용한 좌표 파싱
+		// C 언어 방식 1: sscanf_s를 사용한 파싱
 		int x, y, width, height;
 		if (sscanf_s(line, "%d %d %d %d", &x, &y, &width, &height) == 4)
 		{
@@ -218,41 +221,144 @@ BOOL CTextControlDlg::LoadCoordinatesFromFile(const CString& filename)
 			coords.width = width;
 			coords.height = height;
 			
-			// 각 텍스트 컨트롤의 위치 업데이트
-			switch (controlIndex)
-			{
-			case 0:
-				UpdateTextControlPosition(IDC_TEXT_CONTROL1, coords);
-				break;
-			case 1:
-				UpdateTextControlPosition(IDC_TEXT_CONTROL2, coords);
-				break;
-			case 2:
-				UpdateTextControlPosition(IDC_TEXT_CONTROL3, coords);
-				break;
-			}
+			// 텍스트 컨트롤 위치 업데이트
+			UpdateTextControlPosition_CStyle(controlIndex, &coords);
 			controlIndex++;
+		}
+		else
+		{
+			// C 언어 방식 2: strtok_s를 사용한 파싱 (대안적 방법)
+			int values[4];
+			int valueIndex = 0;
+			
+			token = strtok_s(line, " \t", &context);
+			while (token != NULL && valueIndex < 4)
+			{
+				values[valueIndex] = atoi(token);
+				valueIndex++;
+				token = strtok_s(NULL, " \t", &context);
+			}
+			
+			if (valueIndex == 4)
+			{
+				coords.x = values[0];
+				coords.y = values[1];
+				coords.width = values[2];
+				coords.height = values[3];
+				
+				UpdateTextControlPosition_CStyle(controlIndex, &coords);
+				controlIndex++;
+			}
 		}
 	}
 
 	fclose(file);
-	return (controlIndex > 0); // 최소 하나의 좌표는 로드되어야 함
+	return (controlIndex > 0);
 }
 
-// 텍스트 컨트롤의 위치를 업데이트하는 함수
-void CTextControlDlg::UpdateTextControlPosition(int controlID, const TextControlCoords& coords)
+// 순수 C 언어 스타일 컨트롤 위치 업데이트 함수
+void CTextControlDlg::UpdateTextControlPosition_CStyle(int controlIndex, const TextControlCoords* coords)
 {
-	CWnd* pControl = GetDlgItem(controlID);
-	if (pControl != nullptr)
+	if (coords == NULL)
+		return;
+		
+	CWnd* pControl = NULL;
+	
+	// C 언어 스타일 switch 문
+	switch (controlIndex)
+	{
+	case 0:
+		pControl = GetDlgItem(IDC_TEXT_CONTROL1);
+		break;
+	case 1:
+		pControl = GetDlgItem(IDC_TEXT_CONTROL2);
+		break;
+	case 2:
+		pControl = GetDlgItem(IDC_TEXT_CONTROL3);
+		break;
+	default:
+		return;
+	}
+	
+	if (pControl != NULL && pControl->GetSafeHwnd() != NULL)
 	{
 		// 컨트롤의 위치와 크기 변경
-		pControl->SetWindowPos(nullptr, 
-			coords.x, coords.y, 
-			coords.width, coords.height,
+		pControl->SetWindowPos(NULL, 
+			coords->x, coords->y, 
+			coords->width, coords->height,
 			SWP_NOZORDER | SWP_SHOWWINDOW);
 
 		// 다이얼로그 새로 그리기
 		Invalidate();
 		UpdateWindow();
 	}
+}
+
+// 대안적인 순수 C 언어 파일 읽기 함수 (더 기본적인 방식)
+BOOL CTextControlDlg::LoadCoordinatesFromFile_BasicC(const CString& filename)
+{
+	// CString을 char*로 변환
+	CT2A converter(filename);
+	char* fileName = converter;
+	
+	// 더 기본적인 C 언어 파일 열기
+	FILE* file = fopen(fileName, "r");
+	if (file == NULL)
+	{
+		return FALSE;
+	}
+
+	int coordIndex = 0;
+	char buffer[256];
+	
+	while (fgets(buffer, sizeof(buffer), file) != NULL && coordIndex < 3)
+	{
+		// 주석이나 빈 줄 건너뛰기
+		if (buffer[0] == '#' || buffer[0] == '\n' || buffer[0] == '\r')
+			continue;
+			
+		// 수동 파싱 (더 기본적인 C 방식)
+		char* ptr = buffer;
+		int values[4];
+		int valueCount = 0;
+		
+		// 공백으로 구분된 숫자들을 수동으로 파싱
+		while (*ptr != '\0' && valueCount < 4)
+		{
+			// 공백 건너뛰기
+			while (*ptr == ' ' || *ptr == '\t')
+				ptr++;
+				
+			if (*ptr == '\0')
+				break;
+				
+			// 숫자 읽기
+			values[valueCount] = 0;
+			while (*ptr >= '0' && *ptr <= '9')
+			{
+				values[valueCount] = values[valueCount] * 10 + (*ptr - '0');
+				ptr++;
+			}
+			valueCount++;
+			
+			// 다음 공백까지 이동
+			while (*ptr != ' ' && *ptr != '\t' && *ptr != '\0' && *ptr != '\n')
+				ptr++;
+		}
+		
+		if (valueCount == 4)
+		{
+			TextControlCoords coords;
+			coords.x = values[0];
+			coords.y = values[1];
+			coords.width = values[2];
+			coords.height = values[3];
+			
+			UpdateTextControlPosition_CStyle(coordIndex, &coords);
+			coordIndex++;
+		}
+	}
+	
+	fclose(file);
+	return (coordIndex > 0);
 }

--- a/coordinates.txt
+++ b/coordinates.txt
@@ -1,7 +1,5 @@
-# 텍스트 컨트롤의 좌표 (x, y, width, height)
-# TextControl1
+# 좌표 파일 형식: x y width height
+# TextControl의 위치와 크기 정보
 100 50 200 25
-# TextControl2  
-150 100 250 30
-# TextControl3
-200 150 180 25
+150 100 180 30
+200 150 160 20

--- a/coordinates.txt
+++ b/coordinates.txt
@@ -1,0 +1,7 @@
+# 텍스트 컨트롤의 좌표 (x, y, width, height)
+# TextControl1
+100 50 200 25
+# TextControl2  
+150 100 250 30
+# TextControl3
+200 150 180 25

--- a/pure_c_example.c
+++ b/pure_c_example.c
@@ -1,0 +1,254 @@
+/*
+ * 순수 C 언어로 작성된 좌표 파일 읽기 예제
+ * MFC와 독립적으로 사용할 수 있는 C 함수들
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// C 언어 스타일 좌표 구조체
+typedef struct {
+    int x;
+    int y;
+    int width;
+    int height;
+} Coordinates;
+
+// 함수 프로토타입 선언
+int load_coordinates_from_file(const char* filename, Coordinates coords[], int max_count);
+int parse_coordinate_line(const char* line, Coordinates* coord);
+void print_coordinates(const Coordinates coords[], int count);
+int is_comment_or_empty_line(const char* line);
+void trim_newline(char* line);
+
+/*
+ * 메인 함수 - 사용 예제
+ */
+int main()
+{
+    const char* filename = "coordinates.txt";
+    Coordinates coords[3];  // 최대 3개의 좌표 저장
+    int count;
+    
+    printf("=== 순수 C 언어 좌표 파일 읽기 예제 ===\n\n");
+    
+    // 파일에서 좌표 로드
+    count = load_coordinates_from_file(filename, coords, 3);
+    
+    if (count > 0)
+    {
+        printf("성공적으로 %d개의 좌표를 읽었습니다:\n", count);
+        print_coordinates(coords, count);
+    }
+    else
+    {
+        printf("좌표 파일을 읽는데 실패했습니다.\n");
+        return 1;
+    }
+    
+    return 0;
+}
+
+/*
+ * 파일에서 좌표를 읽어오는 함수
+ * filename: 읽을 파일명
+ * coords: 좌표를 저장할 배열
+ * max_count: 최대 읽을 좌표 개수
+ * 반환값: 성공적으로 읽은 좌표의 개수, 실패시 -1
+ */
+int load_coordinates_from_file(const char* filename, Coordinates coords[], int max_count)
+{
+    FILE* file;
+    char line[256];
+    int count = 0;
+    
+    // 파일 열기
+    file = fopen(filename, "r");
+    if (file == NULL)
+    {
+        printf("파일을 열 수 없습니다: %s\n", filename);
+        return -1;
+    }
+    
+    printf("파일 '%s'을(를) 읽는 중...\n", filename);
+    
+    // 파일에서 한 줄씩 읽기
+    while (fgets(line, sizeof(line), file) != NULL && count < max_count)
+    {
+        // 개행 문자 제거
+        trim_newline(line);
+        
+        // 주석이나 빈 줄 건너뛰기
+        if (is_comment_or_empty_line(line))
+        {
+            continue;
+        }
+        
+        // 좌표 파싱
+        if (parse_coordinate_line(line, &coords[count]) == 1)
+        {
+            printf("라인 파싱 성공: %s\n", line);
+            count++;
+        }
+        else
+        {
+            printf("라인 파싱 실패: %s\n", line);
+        }
+    }
+    
+    fclose(file);
+    return count;
+}
+
+/*
+ * 한 줄에서 좌표를 파싱하는 함수
+ * line: 파싱할 라인
+ * coord: 파싱된 좌표를 저장할 구조체 포인터
+ * 반환값: 성공시 1, 실패시 0
+ */
+int parse_coordinate_line(const char* line, Coordinates* coord)
+{
+    // 방법 1: sscanf 사용
+    if (sscanf(line, "%d %d %d %d", &coord->x, &coord->y, &coord->width, &coord->height) == 4)
+    {
+        return 1;
+    }
+    
+    // 방법 2: 수동 파싱 (sscanf가 실패한 경우)
+    char* line_copy = malloc(strlen(line) + 1);
+    if (line_copy == NULL)
+        return 0;
+        
+    strcpy(line_copy, line);
+    
+    char* token;
+    char* saveptr;
+    int values[4];
+    int i = 0;
+    
+    token = strtok_r(line_copy, " \t", &saveptr);
+    while (token != NULL && i < 4)
+    {
+        values[i] = atoi(token);
+        i++;
+        token = strtok_r(NULL, " \t", &saveptr);
+    }
+    
+    free(line_copy);
+    
+    if (i == 4)
+    {
+        coord->x = values[0];
+        coord->y = values[1];
+        coord->width = values[2];
+        coord->height = values[3];
+        return 1;
+    }
+    
+    return 0;
+}
+
+/*
+ * 좌표 배열을 화면에 출력하는 함수
+ */
+void print_coordinates(const Coordinates coords[], int count)
+{
+    int i;
+    
+    printf("\n좌표 정보:\n");
+    printf("Index | X   | Y   | Width | Height\n");
+    printf("------|-----|-----|-------|-------\n");
+    
+    for (i = 0; i < count; i++)
+    {
+        printf("  %d   | %3d | %3d |  %3d  |  %3d\n", 
+               i, coords[i].x, coords[i].y, coords[i].width, coords[i].height);
+    }
+    printf("\n");
+}
+
+/*
+ * 주석이나 빈 줄인지 확인하는 함수
+ */
+int is_comment_or_empty_line(const char* line)
+{
+    if (line[0] == '#' || line[0] == '\0' || strlen(line) == 0)
+        return 1;
+        
+    // 공백만 있는 줄 확인
+    int i;
+    for (i = 0; line[i] != '\0'; i++)
+    {
+        if (line[i] != ' ' && line[i] != '\t')
+            return 0;
+    }
+    
+    return 1;  // 공백만 있는 줄
+}
+
+/*
+ * 문자열 끝의 개행 문자를 제거하는 함수
+ */
+void trim_newline(char* line)
+{
+    int len = strlen(line);
+    
+    if (len > 0 && (line[len-1] == '\n' || line[len-1] == '\r'))
+    {
+        line[len-1] = '\0';
+        
+        // Windows 스타일 개행 문자 (\r\n) 처리
+        if (len > 1 && line[len-2] == '\r')
+        {
+            line[len-2] = '\0';
+        }
+    }
+}
+
+/*
+ * 대안적인 더 기본적인 파싱 함수 (strtok 없이)
+ */
+int parse_coordinate_line_manual(const char* line, Coordinates* coord)
+{
+    const char* ptr = line;
+    int values[4];
+    int value_count = 0;
+    int current_value = 0;
+    int has_digit = 0;
+    
+    while (*ptr != '\0' && value_count < 4)
+    {
+        if (*ptr >= '0' && *ptr <= '9')
+        {
+            current_value = current_value * 10 + (*ptr - '0');
+            has_digit = 1;
+        }
+        else if ((*ptr == ' ' || *ptr == '\t') && has_digit)
+        {
+            values[value_count] = current_value;
+            value_count++;
+            current_value = 0;
+            has_digit = 0;
+        }
+        ptr++;
+    }
+    
+    // 마지막 값 처리
+    if (has_digit && value_count < 4)
+    {
+        values[value_count] = current_value;
+        value_count++;
+    }
+    
+    if (value_count == 4)
+    {
+        coord->x = values[0];
+        coord->y = values[1];
+        coord->width = values[2];
+        coord->height = values[3];
+        return 1;
+    }
+    
+    return 0;
+}

--- a/resource.h
+++ b/resource.h
@@ -1,21 +1,24 @@
 //{{NO_DEPENDENCIES}}
 // Microsoft Visual C++에서 생성한 포함 파일입니다.
-// TextControlDlg.rc에서 사용되고 있습니다.
+// TextControlApp.rc에서 사용됩니다.
 //
-#define IDD_TEXTCONTROL_DIALOG         1000
-#define IDC_TEXT_CONTROL1              1001
-#define IDC_TEXT_CONTROL2              1002
-#define IDC_TEXT_CONTROL3              1003
-#define IDC_LOAD_COORDINATES           1004
-#define IDC_RESET_POSITIONS            1005
+#define IDM_ABOUTBOX                    0x0010
+#define IDD_ABOUTBOX                    100
+#define IDS_ABOUTBOX                    101
+#define IDD_TEXTCONTROL_DIALOG          102
+#define IDR_MAINFRAME                   128
+#define IDC_TEXT_CONTROL1               1000
+#define IDC_TEXT_CONTROL2               1001
+#define IDC_TEXT_CONTROL3               1002
+#define IDC_BTN_LOAD_COORDS             1003
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        1006
+#define _APS_NEXT_RESOURCE_VALUE        129
 #define _APS_NEXT_COMMAND_VALUE         32771
-#define _APS_NEXT_CONTROL_VALUE         1006
-#define _APS_NEXT_SYMED_VALUE           1000
+#define _APS_NEXT_CONTROL_VALUE         1004
+#define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/resource.h
+++ b/resource.h
@@ -1,0 +1,21 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++에서 생성한 포함 파일입니다.
+// TextControlDlg.rc에서 사용되고 있습니다.
+//
+#define IDD_TEXTCONTROL_DIALOG         1000
+#define IDC_TEXT_CONTROL1              1001
+#define IDC_TEXT_CONTROL2              1002
+#define IDC_TEXT_CONTROL3              1003
+#define IDC_LOAD_COORDINATES           1004
+#define IDC_RESET_POSITIONS            1005
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        1006
+#define _APS_NEXT_COMMAND_VALUE         32771
+#define _APS_NEXT_CONTROL_VALUE         1006
+#define _APS_NEXT_SYMED_VALUE           1000
+#endif
+#endif


### PR DESCRIPTION
Add an MFC example demonstrating dynamic text control positioning by reading coordinates from a file using C-style I/O.

---
<a href="https://cursor.com/background-agent?bcId=bc-db1921c3-afca-472f-8edb-fce3ffe81731">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db1921c3-afca-472f-8edb-fce3ffe81731">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

